### PR TITLE
Add cargo-binutils as a build depency

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,6 +38,8 @@ First, install all the needed software:
 curl https://sh.rustup.rs -sSf | sh
 rustup target add thumbv7m-none-eabi
 sudo apt-get install gdb-arm-none-eabi openocd dfu-util
+cargo install cargo-binutils
+rustup component add llvm-tools-preview
 ```
 
 Compile the firmware:


### PR DESCRIPTION
I'm following the instructions to get started with migrating my keyboard to Keyberon and I found some dependencies are missing.